### PR TITLE
fix: handle proxy watcher errors

### DIFF
--- a/cmd/minecraft-preempt/connection.go
+++ b/cmd/minecraft-preempt/connection.go
@@ -85,7 +85,7 @@ func (c *Connection) Close() error {
 //
 // If the server is not running, it returns a status response with
 // the server's status.
-func (c *Connection) status(ctx context.Context, status cloud.ProviderStatus) error {
+func (c *Connection) status(_ context.Context, status cloud.ProviderStatus) error {
 	if c.hooks.OnStatus != nil {
 		c.hooks.OnStatus()
 	}

--- a/internal/cloud/gcp/client.go
+++ b/internal/cloud/gcp/client.go
@@ -21,11 +21,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jaredallard/minecraft-preempt/v3/internal/cloud"
-
 	compute "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"cloud.google.com/go/compute/metadata"
+	"github.com/jaredallard/minecraft-preempt/v3/internal/cloud"
 )
 
 var (


### PR DESCRIPTION
* i saw the todo so i tried my hand at handling proxy watcher errors. it
  made me realize that the underlying mcnet library doesn't respect
  context very well at all which is probably one of the most important
  places to respect context actually. we should consider contributing
  back to that library to upgrade net.Listen to use net.ListenConfig
  which does respect context.
